### PR TITLE
Add support for running authorized keys command as system

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -236,8 +236,11 @@ get_passwd(const wchar_t * user_utf16, PSID sid)
 		goto cleanup;
 	}
 
-	/* If standard local user name, just use name without decoration */
-	if ((_wcsicmp(domain_name, computer_name) == 0) && (_wcsicmp(computer_name, user_name) != 0))
+	/* if standard local user name or system account, just use name without decoration */
+	const SID_IDENTIFIER_AUTHORITY nt_authority = SECURITY_NT_AUTHORITY;
+	if ((_wcsicmp(domain_name, computer_name) == 0) && (_wcsicmp(computer_name, user_name) != 0) ||
+		memcmp(&nt_authority, GetSidIdentifierAuthority((PSID)binary_sid), sizeof(SID_IDENTIFIER_AUTHORITY)) == 0 && (
+		((SID*)binary_sid)->SubAuthority[0] == SECURITY_LOCAL_SYSTEM_RID))
 		wcscpy_s(user_resolved, ARRAYSIZE(user_resolved), user_name);
 
 	/* put any other format in sam compatible format */

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1074,11 +1074,15 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	
 	wchar_t * t = cmdline_utf16;
 	do {
-		debug3("spawning %ls", t);
-		if (as_user)
+		//debug3("spawning %ls", t);
+		if (as_user) {
+			debug3("spawning %ls as user", t);
 			b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
-		else
+		}
+		else {
+			debug3("spawning %ls as subprocess", t);
 			b = CreateProcessW(NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
+		}
 		if(b || GetLastError() != ERROR_FILE_NOT_FOUND || (argv != NULL && *argv != NULL) || cmd[0] == '\"')
 			break;
 		t++;


### PR DESCRIPTION
- Added support of "system" as a user using NoMoreFood branch https://github.com/PowerShell/openssh-portable/compare/latestw_all...NoMoreFood:ntauthority_as_local
- When command user is "system", launch process as subprocess of the same user instead of attempting launch the process as a different user